### PR TITLE
Added exit to main menu button from options screen

### DIFF
--- a/MainMenu.gd
+++ b/MainMenu.gd
@@ -52,7 +52,7 @@ func _process(_delta):
 func handle_selection(_current_selection):
 	play_button_click()
 	if _current_selection == 0:
-		get_tree().change_scene(scene_locations[$DebugNode/MarginContainer/MapChoice.get_selected_id()][1])
+		Globals.load_new_scene(scene_locations[$DebugNode/MarginContainer/MapChoice.get_selected_id()][1])
 		#get_parent().add_child(scene.instance())
 		#queue_free()
 	elif _current_selection == 1:

--- a/MainMenu.tscn
+++ b/MainMenu.tscn
@@ -269,8 +269,8 @@ __meta__ = {
 
 [node name="OptionPage" type="VBoxContainer" parent="MainMenu"]
 visible = false
-margin_right = 493.0
-margin_bottom = 404.0
+margin_right = 519.0
+margin_bottom = 452.0
 custom_constants/separation = 20
 __meta__ = {
 "_edit_use_anchors_": false

--- a/Utilities/Globals.gd
+++ b/Utilities/Globals.gd
@@ -1,11 +1,14 @@
 extends Node
 
+#### Constants
+const MAIN_MENU_PATH = "res://MainMenu.tscn"
 
 #### Options
 var debug_mode = true
 var show_triggers = false
 var fast_hint = false
 var camera_trigger_debug = false
+
 ##### Control Interface
 var control_panel_ui_scene_pl = preload('res://Utilities/Control_Panel_UI.tscn')
 var control_panel_loaded = false
@@ -47,6 +50,24 @@ func load_dialog_from_file(file_path):
 	assert(JSON_result.error == OK, "Error loading JSON check format!")
 	dialog_JSON_data =  JSON_result.result
 	emit_signal("dialog_loaded")
+	
+func load_new_scene(new_scene_path):
+	get_tree().change_scene(new_scene_path)
+
+func quit_to_main_menu():
+	# Remove all missions
+	for mission_node in get_tree().get_nodes_in_group("Missions"):
+		mission_node.queue_free()
+	
+	# Remove control panel ui
+	control_panel_ui.queue_free()
+	
+	# Remove the robot
+	robot.queue_free()
+		
+	control_panel_loaded = false
+	
+	load_new_scene(MAIN_MENU_PATH)
 
 func init_control_panel():
 	if not control_panel_loaded:

--- a/Utilities/OptionsPanel.gd
+++ b/Utilities/OptionsPanel.gd
@@ -2,7 +2,6 @@ extends MarginContainer
 
 signal options_updated
 
-onready var globals = get_node('/root/Globals')
 onready var font = load("res://Assets/Fonts/NormalTextFont.tres")
 func _on_FontSlider_value_changed(value):
 	
@@ -14,11 +13,19 @@ func _on_VolumeSlider_value_changed(value):
 func _ready():
 	$GridContainer/VolumeSlider.value = AudioServer.get_bus_volume_db(AudioServer.get_bus_index("Master"))
 	$GridContainer/FontSlider.value = font.size
-	$GridContainer/Debug_tools.pressed = globals.debug_mode
-
+	$GridContainer/Debug_tools.pressed = Globals.debug_mode
+	
+	if get_tree().get_current_scene().get_name() == "MainMenu":
+		$GridContainer/QuitButton.visible = false
+		
 func _on_Debug_tools_toggled(button_pressed):
-	globals.debug_mode = button_pressed
+	Globals.debug_mode = button_pressed
 	
 
 func _on_OptionsPanel_visibility_changed():
-	globals.on_options_updated()
+	Globals.on_options_updated()
+
+
+func _on_QuitButton_pressed():
+	Globals.quit_to_main_menu()
+	pass # Replace with function body.

--- a/Utilities/OptionsPanel.tscn
+++ b/Utilities/OptionsPanel.tscn
@@ -20,8 +20,8 @@ __meta__ = {
 [node name="GridContainer" type="GridContainer" parent="."]
 margin_left = 40.0
 margin_top = 40.0
-margin_right = 453.0
-margin_bottom = 164.0
+margin_right = 479.0
+margin_bottom = 212.0
 custom_constants/vseparation = 10
 custom_constants/hseparation = 5
 columns = 2
@@ -40,7 +40,7 @@ align = 1
 
 [node name="FontSlider" type="HSlider" parent="GridContainer"]
 margin_left = 213.0
-margin_right = 413.0
+margin_right = 439.0
 margin_bottom = 32.0
 rect_min_size = Vector2( 200, 0 )
 size_flags_horizontal = 3
@@ -64,7 +64,7 @@ align = 1
 [node name="VolumeSlider" type="HSlider" parent="GridContainer"]
 margin_left = 213.0
 margin_top = 42.0
-margin_right = 413.0
+margin_right = 439.0
 margin_bottom = 74.0
 size_flags_horizontal = 3
 size_flags_vertical = 1
@@ -85,11 +85,26 @@ align = 1
 [node name="Debug_tools" type="CheckButton" parent="GridContainer"]
 margin_left = 213.0
 margin_top = 84.0
-margin_right = 413.0
+margin_right = 439.0
 margin_bottom = 124.0
 size_flags_horizontal = 3
+
+[node name="Empty" type="Label" parent="GridContainer"]
+margin_top = 137.0
+margin_right = 208.0
+margin_bottom = 169.0
+custom_fonts/font = ExtResource( 1 )
+
+[node name="QuitButton" type="Button" parent="GridContainer"]
+margin_left = 213.0
+margin_top = 134.0
+margin_right = 439.0
+margin_bottom = 172.0
+custom_fonts/font = ExtResource( 1 )
+text = "Quit To Main Menu"
 
 [connection signal="visibility_changed" from="." to="." method="_on_OptionsPanel_visibility_changed"]
 [connection signal="value_changed" from="GridContainer/FontSlider" to="." method="_on_FontSlider_value_changed"]
 [connection signal="value_changed" from="GridContainer/VolumeSlider" to="." method="_on_VolumeSlider_value_changed"]
 [connection signal="toggled" from="GridContainer/Debug_tools" to="." method="_on_Debug_tools_toggled"]
+[connection signal="pressed" from="GridContainer/QuitButton" to="." method="_on_QuitButton_pressed"]

--- a/Utilities/Overlays/BookOverlay.tscn
+++ b/Utilities/Overlays/BookOverlay.tscn
@@ -139,6 +139,7 @@ margin_right = 992.0
 margin_bottom = 312.0
 
 [node name="Sensors" type="Panel" parent="OverlayTabs/PanelContainer/MarginContainer/TabContainer"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0


### PR DESCRIPTION
Closes #51 
This PR adds an exit button to the options screen which only shows up in game (if not on MainMenu.tcscn).

The button press triggers a call to `Globals.quit_to_menu()` which queue frees the Control panel ui, the robot, the current missions and sets the control panel ui to off (so that it gets properly recreated next time. 

[Note if other nodes are added to the root, they may also need deleting. to avoid multiple instances of useless nodes... e.g. Mission nodes?] 